### PR TITLE
refactor(deps): remove @graphql-yoga/node

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "typescript"
   ],
   "dependencies": {
-    "@graphql-yoga/node": "3.5.1",
     "@pothos/core": "3.25.0",
     "axios": "1.2.1",
     "graphql": "16.6.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { CORSOptions, YogaInitialContext } from '@graphql-yoga/node'
+import type { CORSOptions, YogaInitialContext } from 'graphql-yoga'
 
 export type Context = YogaInitialContext
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,7 +17,7 @@
     "@envelop/types" "3.0.1"
     tslib "2.4.0"
 
-"@envelop/parser-cache@5.0.4", "@envelop/parser-cache@^5.0.4":
+"@envelop/parser-cache@5.0.4":
   version "5.0.4"
   resolved "https://registry.yarnpkg.com/@envelop/parser-cache/-/parser-cache-5.0.4.tgz#4ff19c16c601c6137a6774fc5660f2e18768c05c"
   integrity sha512-+kp6nzCVLYI2WQExQcE3FSy6n9ZGB5GYi+ntyjYdxaXU41U1f8RVwiLdyh0Ewn5D/s/zaLin09xkFKITVSAKDw==
@@ -40,14 +40,6 @@
     lru-cache "^6.0.0"
     tslib "^2.4.0"
 
-"@envelop/validation-cache@^5.0.5":
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/@envelop/validation-cache/-/validation-cache-5.0.5.tgz#9be1c1ba178460dcaf6d277136a381833cc4f931"
-  integrity sha512-69sq5H7hvxE+7VV60i0bgnOiV1PX9GEJHKrBrVvyEZAXqYojKO3DP9jnLGryiPgVaBjN5yw12ge0l0s2gXbolQ==
-  dependencies:
-    lru-cache "^6.0.0"
-    tslib "^2.4.0"
-
 "@eslint/eslintrc@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.4.1.tgz#af58772019a2d271b7e2d4c23ff4ddcba3ccfb3e"
@@ -62,17 +54,6 @@
     js-yaml "^4.1.0"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
-
-"@graphql-tools/executor@0.0.12":
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/executor/-/executor-0.0.12.tgz#d885c7fa98a8aaeaa771163b71fb98ce9f52f9bd"
-  integrity sha512-bWpZcYRo81jDoTVONTnxS9dDHhEkNVjxzvFCH4CRpuyzD3uL+5w3MhtxIh24QyWm4LvQ4f+Bz3eMV2xU2I5+FA==
-  dependencies:
-    "@graphql-tools/utils" "9.1.4"
-    "@graphql-typed-document-node/core" "3.1.1"
-    "@repeaterjs/repeater" "3.0.4"
-    tslib "^2.4.0"
-    value-or-promise "1.0.12"
 
 "@graphql-tools/executor@0.0.9":
   version "0.0.9"
@@ -130,15 +111,7 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.1.1.tgz#076d78ce99822258cf813ecc1e7fa460fa74d052"
   integrity sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==
 
-"@graphql-yoga/node@3.5.1":
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/@graphql-yoga/node/-/node-3.5.1.tgz#fed5144482fb3918de0113a28adb051fba2f086a"
-  integrity sha512-Pn3X8mf6Cm07J+8Rtz+lb+xn2ufQ9+qsMhYD3Iq2FgG8jin7D15XrqIs5RpCalzALwcLHAvgGhbds6pkYrHnyA==
-  dependencies:
-    graphql-yoga "3.5.1"
-    tslib "^2.3.1"
-
-"@graphql-yoga/subscription@^3.0.0", "@graphql-yoga/subscription@^3.1.0":
+"@graphql-yoga/subscription@^3.0.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@graphql-yoga/subscription/-/subscription-3.1.0.tgz#4a0bb0b9db2602d02c68f9828603e1e40329140b"
   integrity sha512-Vc9lh8KzIHyS3n4jBlCbz7zCjcbtQnOBpsymcRvHhFr2cuH+knmRn0EmzimMQ58jQ8kxoRXXC3KJS3RIxSdPIg==
@@ -398,40 +371,12 @@
     undici "^5.12.0"
     web-streams-polyfill "^3.2.0"
 
-"@whatwg-node/fetch@0.6.5":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@whatwg-node/fetch/-/fetch-0.6.5.tgz#ff96288e9a6295faafac79f13e3b3fd831cad11f"
-  integrity sha512-3XQ78RAMX8Az0LlUqMoGM3jbT+FE0S+IKr4yiTiqzQ5S/pNxD52K/kFLcLQiEbL+3rkk/glCHqjxF1QI5155Ig==
-  dependencies:
-    "@peculiar/webcrypto" "^1.4.0"
-    "@whatwg-node/node-fetch" "0.0.1"
-    busboy "^1.6.0"
-    urlpattern-polyfill "^6.0.2"
-    web-streams-polyfill "^3.2.1"
-
-"@whatwg-node/node-fetch@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@whatwg-node/node-fetch/-/node-fetch-0.0.1.tgz#ffad65f3f8b73d6d2c2e8b179d557a5863b0db13"
-  integrity sha512-dMbh604yf2jl37IzvYGA6z3heQg3dMzlqoNsiNToe46SVmKusfJXGf4KYIuiJTzh9mEEu/uVF//QakUfsLJpwA==
-  dependencies:
-    "@whatwg-node/events" "0.0.2"
-    busboy "1.6.0"
-    tslib "^2.3.1"
-
 "@whatwg-node/server@0.4.17":
   version "0.4.17"
   resolved "https://registry.yarnpkg.com/@whatwg-node/server/-/server-0.4.17.tgz#c40bd644f569e40e4813e7dd6154d7bd77bf1a77"
   integrity sha512-kq1AHyi87VWfiDqiSTAOY+py83HMJg42+fI8JAe1wjmMkJ8v/E5mKq5NpLNRM9Cnf7NHsQR0AwQgvX/RFuptaA==
   dependencies:
     "@whatwg-node/fetch" "0.5.3"
-    tslib "^2.3.1"
-
-"@whatwg-node/server@0.5.11":
-  version "0.5.11"
-  resolved "https://registry.yarnpkg.com/@whatwg-node/server/-/server-0.5.11.tgz#ac5360bc872811eb19c526341e36b36e12b275c0"
-  integrity sha512-MXG2MWE2Cf4nNwZ5Kpq2VueNSxD2Y0DWNBH0FmsGdFOI4DudK8TZfbPXFEFG2b+wXrpkyi7s8Q86Htr62m0pSQ==
-  dependencies:
-    "@whatwg-node/fetch" "0.6.5"
     tslib "^2.3.1"
 
 abort-controller@^3.0.0:
@@ -554,7 +499,7 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
-busboy@1.6.0, busboy@^1.6.0:
+busboy@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/busboy/-/busboy-1.6.0.tgz#966ea36a9502e43cdb9146962523b92f531f6893"
   integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
@@ -982,23 +927,6 @@ graphql-yoga@3.1.1:
     "@graphql-yoga/subscription" "^3.0.0"
     "@whatwg-node/fetch" "0.5.3"
     "@whatwg-node/server" "0.4.17"
-    dset "^3.1.1"
-    tslib "^2.3.1"
-
-graphql-yoga@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/graphql-yoga/-/graphql-yoga-3.5.1.tgz#46eed5ca162f153cf37a5074d22214505c241be4"
-  integrity sha512-DVn/r4L9XJs5XeVJY9BqOHXk6P2Z1iNB9vXfChcEGNpfxJCbY6pKBstGdlDY+93U0lq5aLVspeOTvBWXAN90/w==
-  dependencies:
-    "@envelop/core" "3.0.4"
-    "@envelop/parser-cache" "^5.0.4"
-    "@envelop/validation-cache" "^5.0.5"
-    "@graphql-tools/executor" "0.0.12"
-    "@graphql-tools/schema" "^9.0.0"
-    "@graphql-tools/utils" "^9.0.1"
-    "@graphql-yoga/subscription" "^3.1.0"
-    "@whatwg-node/fetch" "0.6.5"
-    "@whatwg-node/server" "0.5.11"
     dset "^3.1.1"
     tslib "^2.3.1"
 
@@ -1579,13 +1507,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-urlpattern-polyfill@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/urlpattern-polyfill/-/urlpattern-polyfill-6.0.2.tgz#a193fe773459865a2a5c93b246bb794b13d07256"
-  integrity sha512-5vZjFlH9ofROmuWmXM9yj2wljYKgWstGwe8YTyiqM7hVum/g9LyCizPZtb3UqsuppVwety9QJmfc42VggLpTgg==
-  dependencies:
-    braces "^3.0.2"
-
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -1606,7 +1527,7 @@ web-streams-polyfill@4.0.0-beta.3:
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz#2898486b74f5156095e473efe989dcf185047a38"
   integrity sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==
 
-web-streams-polyfill@^3.2.0, web-streams-polyfill@^3.2.1:
+web-streams-polyfill@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
   integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==


### PR DESCRIPTION
The package is deprecated in favour of [graphql-yoga](https://www.npmjs.com/package/graphql-yoga)

Ref: https://www.npmjs.com/package/@graphql-yoga/node/v/3.6.1

Closes #21 